### PR TITLE
Fix invalid network interface stat reporting

### DIFF
--- a/lib/app_perf_agent/plugin/system/network.rb
+++ b/lib/app_perf_agent/plugin/system/network.rb
@@ -6,7 +6,7 @@ module AppPerfAgent
     module System
       class Network < AppPerfAgent::Plugin::Base
         def call
-          inets = Vmstat.ethernet_devices
+          inets = Vmstat.network_interfaces
           inets.flat_map {|inet|
             [
               ["system.network.in_bytes", inet.in_bytes, { "name" => inet.name.to_s }],


### PR DESCRIPTION
Before:
```ruby
[1] pry(#<AppPerfAgent::Plugin::System::Network>)> Vmstat.ethernet_devices
=> []
```
After:

```ruby
[1] pry(#<AppPerfAgent::Plugin::System::Network>)> inets
=> [#<struct Vmstat::NetworkInterface
  name=:lo,
  in_bytes=30488,
  in_errors=0,
  in_drops=0,
  out_bytes=30488,
  out_errors=0,
  type=24>,
 #<struct Vmstat::NetworkInterface
  name=:ens160,
  in_bytes=86470584,
  in_errors=0,
  in_drops=0,
  out_bytes=889423,
  out_errors=0,
  type=nil>]
```